### PR TITLE
Use valid SPDX license identifier in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
       "url": "https://github.com/mklement0"
     }
   ],
-  "license": "Apache version 2.0",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/barsh/true-case-path/issues"
   },


### PR DESCRIPTION
According to [NPM documentation](https://docs.npmjs.com/files/package.json#license) license field should container valid SPDX license identifier. Having invalid identifier makes it hard to use automated software to analyze dependencies to ensure that they only contain approved licenses.